### PR TITLE
feat: add ClawHub ban appeal form

### DIFF
--- a/forms.config.ts
+++ b/forms.config.ts
@@ -2,6 +2,7 @@ import type { FormConfig, FormField } from "./src/forms/types.js"
 
 export const formSettings = {
 	reviewChannelId: "1467242758183059536",
+	clawhubAppealReviewChannelId: "1498032057337647295",
 	shadowChannelId: "1464886408090226902",
 	discordGuildId: "1456350064065904867",
 	githubOrg: "openclaw",
@@ -100,6 +101,26 @@ export const formConfigs = [
 					type: "github.unblockOrgUser",
 					org: formSettings.githubOrg,
 					target: "authUsername"
+				}
+			],
+			deny: []
+		}
+	},
+	{
+		id: "clawhub",
+		title: "ClawHub Ban Appeal",
+		description: "Request a ClawHub account ban review.",
+		auth: "github",
+		requiredAction: "banned",
+		reviewChannelId: formSettings.clawhubAppealReviewChannelId,
+		successMessage: "Submitted.",
+		fields: appealFields,
+		actions: {
+			accept: [
+				{
+					type: "clawhub.unbanUser",
+					target: "clawhubUserId",
+					reason: "Appeal accepted."
 				}
 			],
 			deny: []

--- a/forms.config.ts
+++ b/forms.config.ts
@@ -4,7 +4,7 @@ export const formSettings = {
 	reviewChannelId: "1467242758183059536",
 	reviewRoleId: "1477360613125787678",
 	clawhubAppealReviewChannelId: "1498032057337647295",
-	clawhubAppealReviewRoleId: null,
+	clawhubAppealReviewRoleId: "1509967254870298794",
 	shadowChannelId: "1464886408090226902",
 	shadowReviewRoleId: "1477504469473427497",
 	discordGuildId: "1456350064065904867",

--- a/forms.config.ts
+++ b/forms.config.ts
@@ -2,8 +2,11 @@ import type { FormConfig, FormField } from "./src/forms/types.js"
 
 export const formSettings = {
 	reviewChannelId: "1467242758183059536",
+	reviewRoleId: "1477360613125787678",
 	clawhubAppealReviewChannelId: "1498032057337647295",
+	clawhubAppealReviewRoleId: null,
 	shadowChannelId: "1464886408090226902",
+	shadowReviewRoleId: "1477504469473427497",
 	discordGuildId: "1456350064065904867",
 	githubOrg: "openclaw",
 	redditSubreddit: "openclaw"
@@ -51,6 +54,7 @@ export const formConfigs = [
 		auth: "discord",
 		requiredAction: "banned",
 		reviewChannelId: formSettings.reviewChannelId,
+		reviewRoleId: formSettings.reviewRoleId,
 		successMessage: "Submitted.",
 		fields: appealFields,
 		actions: {
@@ -72,6 +76,7 @@ export const formConfigs = [
 		auth: "discord",
 		requiredAction: "muted",
 		reviewChannelId: formSettings.reviewChannelId,
+		reviewRoleId: formSettings.reviewRoleId,
 		successMessage: "Submitted.",
 		fields: appealFields,
 		actions: {
@@ -93,6 +98,7 @@ export const formConfigs = [
 		auth: "github",
 		requiredAction: "banned",
 		reviewChannelId: formSettings.reviewChannelId,
+		reviewRoleId: formSettings.reviewRoleId,
 		successMessage: "Submitted.",
 		fields: appealFields,
 		actions: {
@@ -113,6 +119,7 @@ export const formConfigs = [
 		auth: "github",
 		requiredAction: "banned",
 		reviewChannelId: formSettings.clawhubAppealReviewChannelId,
+		reviewRoleId: formSettings.clawhubAppealReviewRoleId,
 		successMessage: "Submitted.",
 		fields: appealFields,
 		actions: {
@@ -133,6 +140,7 @@ export const formConfigs = [
 		auth: "reddit",
 		requiredAction: "banned",
 		reviewChannelId: formSettings.reviewChannelId,
+		reviewRoleId: formSettings.reviewRoleId,
 		successMessage: "Submitted.",
 		fields: appealFields,
 		actions: {
@@ -153,6 +161,7 @@ export const formConfigs = [
 		description: "Report moderator misconduct.",
 		auth: ["discord", "github", "reddit"],
 		reviewChannelId: formSettings.shadowChannelId,
+		reviewRoleId: formSettings.shadowReviewRoleId,
 		successMessage: "Submitted.",
 		fields: [
 			{

--- a/src/events/gifRepostMessageCreate.ts
+++ b/src/events/gifRepostMessageCreate.ts
@@ -33,7 +33,7 @@ const findGifLink = (content: string) => {
 			continue
 		}
 	}
-	return null
+	return undefined
 }
 
 const fetchChannel = async (client: Client, channelId: string) =>

--- a/src/forms/actions.ts
+++ b/src/forms/actions.ts
@@ -66,6 +66,46 @@ const resolveDiscordAppeal = async (action: Extract<FormAction, { type: "discord
 	return "No active Discord punishment found."
 }
 
+const clawHubApiBase = () => (process.env["CLAWHUB_API_BASE"] || "https://clawhub.ai").replace(/\/$/, "")
+
+const getClawHubHeaders = () => {
+	const token = process.env["CLAWHUB_BAN_APPEALS_TOKEN"]
+	if (!token) {
+		throw new Error("CLAWHUB_BAN_APPEALS_TOKEN is not configured.")
+	}
+	return {
+		Authorization: `Bearer ${token}`,
+		"content-type": "application/json"
+	}
+}
+
+const clawHubUnbanRequest = async (
+	action: Extract<FormAction, { type: "clawhub.unbanUser" }>,
+	submission: FormSubmission,
+	options: { reviewerDiscordId?: string }
+) => {
+	const target = resolveTarget(action.target, submission)
+	if (!target) {
+		throw new Error("ClawHub user ID is missing from submission context.")
+	}
+	if (!options.reviewerDiscordId) {
+		throw new Error("Reviewer Discord ID is missing.")
+	}
+	const response = await fetch(`${clawHubApiBase()}/api/v1/users/ban-appeal-unban`, {
+		method: "POST",
+		headers: getClawHubHeaders(),
+		body: JSON.stringify({
+			userId: target,
+			reason: action.reason ?? `Form ${submission.id}`,
+			reviewerDiscordId: options.reviewerDiscordId
+		})
+	})
+	if (!response.ok) {
+		throw new Error(`ClawHub ${response.status}: ${await response.text()}`)
+	}
+	return "clawhub.unbanUser"
+}
+
 const redditRequest = async (action: Extract<FormAction, { type: "reddit.unbanSubredditUser" }>, submission: FormSubmission) => {
 	const url = requireValue(process.env.DEVVIT_REDDIT_ACTION_URL ?? "", "DEVVIT_REDDIT_ACTION_URL")
 	const secret = requireValue(process.env.DEVVIT_REDDIT_BRIDGE_SECRET ?? "", "DEVVIT_REDDIT_BRIDGE_SECRET")
@@ -97,12 +137,19 @@ const redditRequest = async (action: Extract<FormAction, { type: "reddit.unbanSu
 	return "reddit.unbanSubredditUser"
 }
 
-const runAction = async (action: FormAction, submission: FormSubmission) => {
+const runAction = async (
+	action: FormAction,
+	submission: FormSubmission,
+	options: { reviewerDiscordId?: string }
+) => {
 	if (action.type === "discord.resolveAppeal") {
 		return resolveDiscordAppeal(action, submission)
 	}
 	if (action.type === "reddit.unbanSubredditUser") {
 		return redditRequest(action, submission)
+	}
+	if (action.type === "clawhub.unbanUser") {
+		return clawHubUnbanRequest(action, submission, options)
 	}
 	if (action.type === "discord.addRole" || action.type === "discord.removeRole") {
 		const method = action.type === "discord.addRole" ? "PUT" : "DELETE"
@@ -152,12 +199,13 @@ const runAction = async (action: FormAction, submission: FormSubmission) => {
 export const runFormActions = async (
 	form: FormConfig,
 	submission: FormSubmission,
-	decision: "accept" | "deny"
+	decision: "accept" | "deny",
+	options: { reviewerDiscordId?: string } = {}
 ) => {
 	const actions: readonly FormAction[] = form.actions[decision]
 	const results: string[] = []
 	for (const action of actions) {
-		results.push(await runAction(action, submission))
+		results.push(await runAction(action, submission, options))
 	}
 	return results.length > 0 ? results.join(", ") : "No external action required."
 }

--- a/src/forms/context.ts
+++ b/src/forms/context.ts
@@ -203,6 +203,51 @@ const latestGitHubContext = async (username: string) => {
 	}
 }
 
+type ClawHubBanAppealContext = {
+	action?: "banned" | "moderated"
+	userId?: string | null
+	handle?: string | null
+	displayName?: string | null
+	banReason?: string | null
+	bannedAt?: number | null
+	auditAction?: string | null
+	auditActorUserId?: string | null
+}
+
+const clawHubApiBase = () => (process.env["CLAWHUB_API_BASE"] || "https://clawhub.ai").replace(/\/$/, "")
+
+const getClawHubHeaders = () => {
+	const token = process.env["CLAWHUB_BAN_APPEALS_TOKEN"]
+	if (!token) {
+		throw new Error("CLAWHUB_BAN_APPEALS_TOKEN is not configured.")
+	}
+	return { Authorization: `Bearer ${token}` }
+}
+
+const latestClawHubContext = async (providerAccountId: string) => {
+	const url = new URL(`${clawHubApiBase()}/api/v1/users/ban-appeal-context`)
+	url.searchParams.set("githubProviderAccountId", providerAccountId)
+	const response = await fetch(url, { headers: getClawHubHeaders() })
+	if (!response.ok) {
+		throw new Error(`ClawHub ${response.status}: ${await response.text()}`)
+	}
+	const context = await response.json() as ClawHubBanAppealContext
+	return {
+		action: context.action ?? "moderated",
+		unaction: context.action === "banned" ? "unbanned" : "reviewed",
+		clawhubUserId: context.userId ?? "",
+		clawhubHandle: context.handle ? `@${context.handle}` : notAvailable,
+		account: context.displayName ?? context.handle ?? notAvailable,
+		banReason: context.banReason || noListedReason,
+		moderationReason: context.banReason || noListedReason,
+		date: context.bannedAt ? new Date(context.bannedAt).toISOString() : notAvailable,
+		scope: "ClawHub account",
+		auditAction: context.auditAction ?? notAvailable,
+		auditActorUserId: context.auditActorUserId ?? notAvailable,
+		links: context.handle ? `${clawHubApiBase()}/${context.handle}` : clawHubApiBase()
+	}
+}
+
 const latestRedditContext = async (username: string) => {
 	const subreddit = formSettings.redditSubreddit
 	const normalized = normalizeRedditUsername(username)
@@ -232,6 +277,9 @@ export const fetchFormContext = async (
 	}
 	if (form.id === "github") {
 		return latestGitHubContext(user.username)
+	}
+	if (form.id === "clawhub") {
+		return latestClawHubContext(user.id)
 	}
 	if (form.id === "reddit") {
 		return latestRedditContext(user.username)

--- a/src/forms/forms.ts
+++ b/src/forms/forms.ts
@@ -3,18 +3,26 @@ import type { FormAuthProvider, FormConfig } from "./types.js"
 
 export const formConfigs = configuredFormConfigs
 
+const discordConfigured = () => Boolean(process.env.DISCORD_CLIENT_ID && process.env.DISCORD_CLIENT_SECRET)
+const githubConfigured = () => Boolean(process.env.GITHUB_OAUTH_CLIENT_ID && process.env.GITHUB_OAUTH_CLIENT_SECRET)
 const redditConfigured = () => Boolean(process.env.REDDIT_OAUTH_CLIENT_ID && process.env.REDDIT_OAUTH_CLIENT_SECRET)
+const clawHubConfigured = () => Boolean(process.env["CLAWHUB_BAN_APPEALS_TOKEN"])
 
 export const isFormAuthProviderAvailable = (provider: FormAuthProvider) => {
-	if (provider === "reddit") {
-		return redditConfigured()
-	}
+	if (provider === "discord") return discordConfigured()
+	if (provider === "github") return githubConfigured()
+	if (provider === "reddit") return redditConfigured()
+	return true
+}
+
+const isFormIntegrationAvailable = (form: FormConfig) => {
+	if (form.id === "clawhub") return clawHubConfigured()
 	return true
 }
 
 export const getFormAuthProviders = (form: FormConfig) => {
 	const providers = Array.isArray(form.auth) ? form.auth : [form.auth]
-	return providers.filter(isFormAuthProviderAvailable)
+	return isFormIntegrationAvailable(form) ? providers.filter(isFormAuthProviderAvailable) : []
 }
 
 export const getAvailableFormConfigs = () =>

--- a/src/forms/reviewButtons.ts
+++ b/src/forms/reviewButtons.ts
@@ -54,6 +54,9 @@ const titleFor = (form: FormConfig, submission: FormSubmission) => {
 	if (form.id === "github") {
 		return `GitHub Ban Appeal sent by @${applicantName(submission)}`
 	}
+	if (form.id === "clawhub") {
+		return `ClawHub Ban Appeal sent by @${applicantName(submission)}`
+	}
 	if (form.id === "reddit") {
 		return `Reddit Ban Appeal sent by @${applicantName(submission)}`
 	}
@@ -113,6 +116,20 @@ const detailComponentsFor = (form: FormConfig, submission: FormSubmission) => {
 			detailField("Links", payload.links)
 		].join("\n"))]
 	}
+	if (form.id === "clawhub") {
+		return [new TextDisplay([
+			detailField("GitHub user", `@${applicantName(submission)}`),
+			detailField("GitHub ID", submission.applicantId ?? "Unknown"),
+			detailField("ClawHub user", payload.clawhubHandle || payload.account),
+			detailField("ClawHub ID", payload.clawhubUserId),
+			detailField("Scope", payload.scope || "Unknown"),
+			detailField("Reason", payload.banReason),
+			detailField("Date", payload.date),
+			detailField("Audit action", payload.auditAction),
+			detailField("Audit actor", payload.auditActorUserId),
+			detailField("Links", payload.links)
+		].join("\n"))]
+	}
 	if (form.id === "reddit") {
 		return [new TextDisplay([
 			detailField("Reddit user", applicantName(submission)),
@@ -145,6 +162,9 @@ const answerLinesFor = (form: FormConfig, submission: FormSubmission) => {
 			}
 			if (form.id === "github") {
 				return !["scope", "links"].includes(field.id)
+			}
+			if (form.id === "clawhub") {
+				return !["scope", "links", "auditAction", "auditActorUserId", "clawhubUserId", "clawhubHandle", "date"].includes(field.id)
 			}
 			return true
 		})
@@ -299,8 +319,8 @@ const decide = async (
 	let actionResult = duration ? `New duration requested: ${duration}` : "No external action required."
 	try {
 		actionResult = status === "accepted"
-			? await runFormActions(loaded.form, loaded.submission, "accept")
-			: await runFormActions(loaded.form, loaded.submission, "deny")
+			? await runFormActions(loaded.form, loaded.submission, "accept", { reviewerDiscordId: interaction.user?.id })
+			: await runFormActions(loaded.form, loaded.submission, "deny", { reviewerDiscordId: interaction.user?.id })
 		if (duration) {
 			actionResult = `${actionResult}\nNew duration: ${duration}`
 		}

--- a/src/forms/reviewButtons.ts
+++ b/src/forms/reviewButtons.ts
@@ -228,6 +228,7 @@ export const buildFormReviewContainer = (
 	].filter((line): line is string => Boolean(line))
 	return new Container(
 		[
+			...(form.reviewRoleId ? [new TextDisplay(`-# <@&${form.reviewRoleId}>`)] : []),
 			new TextDisplay(`## ${titleFor(form, submission)}`),
 			...detailComponentsFor(form, submission),
 			new Separator({ divider: true, spacing: "small" }),

--- a/src/forms/reviewButtons.ts
+++ b/src/forms/reviewButtons.ts
@@ -258,6 +258,21 @@ const resultContainer = (title: string, body: string, color: string) =>
 		accentColor: color
 	})
 
+const canReview = (interaction: ButtonInteraction | ModalInteraction, form: FormConfig) =>
+	!form.reviewRoleId || (interaction.member?.roles.some((role) => role.id === form.reviewRoleId) ?? false)
+
+const requireReviewRole = async (interaction: ButtonInteraction | ModalInteraction, form: FormConfig) => {
+	if (canReview(interaction, form)) {
+		return true
+	}
+	await interaction.reply({
+		components: [resultContainer("Review role required", `You need <@&${form.reviewRoleId}> to review this submission.`, "#f85149")],
+		ephemeral: true,
+		allowedMentions: { parse: [] }
+	})
+	return false
+}
+
 const loadSubmission = async (id: unknown) => {
 	if (typeof id !== "number") {
 		return { error: "Missing submission id." }
@@ -312,6 +327,10 @@ const decide = async (
 			components: [resultContainer("Invalid form submission", loaded.error ?? "Unknown error.", "#f85149")],
 			ephemeral: true
 		})
+		return
+	}
+
+	if (!(await requireReviewRole(interaction, loaded.form))) {
 		return
 	}
 
@@ -473,6 +492,9 @@ export class FormReviewAcceptButton extends Button {
 			})
 			return
 		}
+		if (!(await requireReviewRole(interaction, loaded.form))) {
+			return
+		}
 		await interaction.showModal(new FormReviewDecisionModal("accepted", loaded.id))
 	}
 }
@@ -499,6 +521,9 @@ export class FormReviewDenyButton extends Button {
 			})
 			return
 		}
+		if (!(await requireReviewRole(interaction, loaded.form))) {
+			return
+		}
 		await interaction.showModal(new FormReviewDecisionModal("denied", loaded.id))
 	}
 }
@@ -522,6 +547,9 @@ export class FormReviewLockButton extends Button {
 			await interaction.reply({
 				components: [resultContainer("Invalid form submission", loaded.error ?? "Unknown error.", "#f85149")]
 			})
+			return
+		}
+		if (!(await requireReviewRole(interaction, loaded.form))) {
 			return
 		}
 		const locked = await recordFormLock(loaded.id)

--- a/src/forms/server.tsx
+++ b/src/forms/server.tsx
@@ -145,7 +145,7 @@ const sendReview = async (
 	}
 	const message = await channel.send({
 		components: [buildFormReviewContainer(form, submission)],
-		allowedMentions: { parse: [] }
+		allowedMentions: form.reviewRoleId ? { roles: [form.reviewRoleId], users: [] } : { parse: [] }
 	})
 	const threadResponse = await fetch(
 		`${discordApiBase}/channels/${form.reviewChannelId}/messages/${message.id}/threads`,

--- a/src/forms/types.ts
+++ b/src/forms/types.ts
@@ -57,4 +57,5 @@ export type FormAction =
 	| { type: "discord.resolveAppeal"; guildId: string; target: FormTarget; reason?: string }
 	| { type: "github.blockOrgUser"; org: string; target: FormTarget }
 	| { type: "github.unblockOrgUser"; org: string; target: FormTarget }
+	| { type: "clawhub.unbanUser"; target: FormTarget; reason?: string }
 	| { type: "reddit.unbanSubredditUser"; subreddit: string; target: FormTarget; reason?: string }

--- a/src/forms/types.ts
+++ b/src/forms/types.ts
@@ -42,6 +42,7 @@ export type FormConfig = {
 	auth: FormAuthProvider | FormAuthProvider[]
 	requiredAction?: Exclude<ModerationAction, "moderated">
 	reviewChannelId: string
+	reviewRoleId: string | null
 	successMessage: string
 	fields: FormField[]
 	actions: { accept: FormAction[]; deny: FormAction[] }

--- a/src/server/claimServer.ts
+++ b/src/server/claimServer.ts
@@ -27,7 +27,7 @@ import {
 import { getRuntimeEnv } from "../runtime/env.js"
 
 const clawtributorsRoleId = "1458375944111915051"
-const claimReviewRoleId = "1460436814627078433"
+const claimReviewRoleId = "1477360613125787678"
 const claimReviewChannelId = "1503772785120383057"
 const clawtributorsAnnouncementChannelId = "1458141495701012561"
 const githubOwner = "openclaw"
@@ -838,7 +838,7 @@ const handleClaimCallback = async (request: Request, client: Client) => {
 			components: [
 				new Container(
 					[
-						new TextDisplay(`<@&${claimReviewRoleId}>`),
+						new TextDisplay(`-# <@&${claimReviewRoleId}>`),
 						new TextDisplay("### Clawtributor Claim Request"),
 						new TextDisplay(
 							`- User: <@${payload.userId}>\n- ID: ${payload.userId}\n- GitHub: [@${qualifyingSummary.username}](<https://github.com/${qualifyingSummary.username}>)\n- Merged PRs: **${qualifyingSummary.totalCount}**`


### PR DESCRIPTION
## Summary
- add a ClawHub Ban Appeal form at `/clawhub`
- send ClawHub appeal reviews to channel `1498032057337647295`
- fetch ClawHub ban context with GitHub OAuth numeric id
- accept ClawHub appeals by calling the dedicated ClawHub ban-appeals service endpoint

## Required env
- `CLAWHUB_BAN_APPEALS_TOKEN`: shared bearer token matching the Convex backend env
- optional `CLAWHUB_API_BASE`: defaults to `https://clawhub.ai`

## Tests
- `bun run forms:css && bunx tsc --noEmit`


## Companion PR
- https://github.com/openclaw/clawhub/pull/2408
